### PR TITLE
Use org.apache.commons.lang3

### DIFF
--- a/repastcity3/src/repastcity3/environment/Route.java
+++ b/repastcity3/src/repastcity3/environment/Route.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
 import java.util.Map;
 import java.util.Vector;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.geotools.referencing.GeodeticCalculator;
 
 import cern.colt.Arrays;


### PR DESCRIPTION
Instead of the legacy `org.apache.commons.lang.

Newer Repast Simphony versions (at least Repast Simphony 2.6)
include `commons.lang3`, but not `commons.lang`.